### PR TITLE
Allow assert_throws to check that it throws without testing more

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -254,16 +254,15 @@ policies and contribution forms [3].
  *   assert that property property_name on object is readonly
  *
  * assert_throws(code, func, description)
- *   code - a DOMException/RangeException code as a string, e.g. "HIERARCHY_REQUEST_ERR"
+ *   code - the expected exception:
+ *     o string: the thrown exception must be a DOMException with the given
+ *               name, e.g., "TimeoutError" (for compatibility with existing
+ *               tests, a constant is also supported, e.g., "TIMEOUT_ERR")
+ *     o object: the thrown exception must have a property called "name" that
+ *               matches code.name
+ *     o null:   allow any exception (in general, one of the options above
+ *               should be used)
  *   func - a function that should throw
- *
- *   assert that func throws a DOMException or RangeException (as appropriate)
- *   with the given code.  If an object is passed for code instead of a string,
- *   checks that the thrown exception has a property called "name" that matches
- *   the property of code called "name".  Finally, if a literal null is passed
- *   for /code/, it will only check that it throws, not what, you should
- *   probably *never* use this.  Note, this function will probably be rewritten
- *   sometime to make more sense.
  *
  * assert_unreached(description)
  *   asserts if called. Used to ensure that some codepath is *not* taken e.g.


### PR DESCRIPTION
12:48 < odinho> jgraham, Ms2ger, AryehGregor, other testharness.js people: I kinda want a way to say "WTF don't care" about the exception being thrown in    assert_throws().
12:49 < Ms2ger> Why? :)
12:49 < odinho> I have the CORS-tests, and what the XHR throws is really not that important.
12:49 < odinho> In fact, it hasn't anything to do with CORS.
12:49 < odinho> And Mozilla is failing HARD, along with Webkit because of that.
12:49 < odinho> Masking other, possibly real bugs.

12:56 < Ms2ger> odinho, I'd prefer (null, fn), because really I'd rather people don't do it :)
12:56 < odinho> Ms2ger: Okay, fair enough.
12:57 < odinho> Ms2ger: Like, you have to, know what you're doing/really want it, if you do it.
12:57 < Ms2ger> Right
