### PR TITLE
Escape literaly placed backslashes

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -442,6 +442,7 @@ policies and contribution forms [3].
         switch (typeof val)
         {
         case "string":
+            val = val.replace("\\", "\\\\");
             for (var i = 0; i < 32; i++)
             {
                 var replace = "\\";


### PR DESCRIPTION
Given this code:

```
test(function() {
    assert_equals("\n", "\\n");
});
```

Before:

```
assert_equals: expected "\n" but got "\n"
```

After:

```
assert_equals: expected "\\n" but got "\n"
```
