### PR TITLE
Display variable types in assert_equals if different

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -584,12 +584,15 @@ policies and contribution forms [3].
           * Test if two primitives are equal or two objects
           * are the same object
           */
-        var error_message = "expected ${expected} but got ${actual}";
         if (typeof actual != typeof expected)
         {
-            error_message = "expected (" + typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}";
+            assert(false, "assert_equals", description,
+                          "expected (" + typeof expected + ") ${expected} but got (" + typeof actual + ") ${actual}",
+                          {expected:expected, actual:actual});
+            return;
         }
-        assert(same_value(actual, expected), "assert_equals", description, error_message,
+        assert(same_value(actual, expected), "assert_equals", description,
+                                             "expected ${expected} but got ${actual}",
                                              {expected:expected, actual:actual});
     };
     expose(assert_equals, "assert_equals");


### PR DESCRIPTION
Before:

```
assert_equals: expected 1 but got "1"
```

After:

```
assert_equals: expected (number) 1 but got (string) "1"
```

This is a stupid example, but other times it might be nice to know the types when they are different.
