### PR TITLE
Allow async_test to also take a function as first argument.

### DIFF
--- a/apisample.htm
+++ b/apisample.htm
@@ -99,7 +99,15 @@
     }, "Test assert_throws with non-DOM-exception expected to Fail");
 
     var t = async_test("Test step_func")
-    setTimeout(t.step_func(function (){assert_true(true); t.done();}, 0));
+    setTimeout(t.step_func(function (){assert_true(true); t.done();}), 0);
+
+    async_test(function(t) {
+        setTimeout(t.step_func(function (){assert_true(true); t.done();}), 0);
+    }, "Test async test with callback");
+
+    async_test(function() {
+        setTimeout(this.step_func(function (){assert_true(true); this.done();}), 0);
+    }, "Test async test with callback and `this` obj.");
 
     async_test("test should timeout (fail) with the default of 2 seconds").step(function(){});
 

--- a/testharness.js
+++ b/testharness.js
@@ -94,6 +94,19 @@ policies and contribution forms [3].
  *
  * t.done();
  *
+ * As a convenience, async_test can also takes a function as first argument.
+ * This function is called with the test object as both its `this` object and
+ * first argument. The above example can be rewritten as:
+ *
+ * async_test(function(t) {
+ *     object.some_event = function() {
+ *         t.step(function (){assert_true(true); t.done();});
+ *     };
+ * }, "Simple async test");
+ *
+ * which avoids cluttering the global scope with references to async
+ * tests instances.
+ *
  * The properties argument is identical to that for test().
  *
  * In many cases it is convenient to run a step in response to an event or a
@@ -392,11 +405,19 @@ policies and contribution forms [3].
         }
     }
 
-    function async_test(name, properties)
+    function async_test(func, name, properties)
     {
+        if (typeof func !== "function") {
+            properties = name;
+            name = func;
+            func = null;
+        }
         var test_name = name ? name : next_default_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
+        if (func) {
+            test_obj.step(func, test_obj, test_obj);
+        }
         return test_obj;
     }
 


### PR DESCRIPTION
This function is called with the test object as both its `this` object and first argument. This avoids cluttering the global scope with lots of references to test instances.

```
async_test(function(t) {
    object.some_event = function() {
        t.step(function (){assert_true(true); t.done();});
    };
}, "Simple async test");
```
