### PR TITLE
Make step() return the argument's return value

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1118,7 +1118,7 @@ policies and contribution forms [3].
 
         try
         {
-            func.apply(this_obj, Array.prototype.slice.call(arguments, 2));
+            return func.apply(this_obj, Array.prototype.slice.call(arguments, 2));
         }
         catch(e)
         {


### PR DESCRIPTION
One problem I ran into was that I wanted to use the return value of a step(), like so:

```
  var rv = this.step(func);
```

Currently rv will be undefined.

This is convenient when having writing tests as follows:

check('description of test', function() { return new Blob(''); }, function(ev, input) { assert.... });

where the second argument is the "input", but needs to be run in a step because it might throw an exception, and I want to keep a reference to the return value so I can pass it in an argument to function(ev, input) { assert.... } instead of using a global variable.
