### PR TITLE
Use textContent to avoid an exception when the title element has no children.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -399,7 +399,7 @@ policies and contribution forms [3].
     {
         //Don't use document.title to work around an Opera bug in XHTML documents
         var prefix = document.getElementsByTagName("title").length > 0 ?
-                         document.getElementsByTagName("title")[0].firstChild.data :
+                         document.getElementsByTagName("title")[0].textContent :
                          "Untitled";
         var suffix = name_counter > 0 ? " " + name_counter : "";
         name_counter++;


### PR DESCRIPTION
As reported by Alan Stearns.
