### PR TITLE
Do not set the timeout when creating a Tests object

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1392,6 +1392,10 @@ policies and contribution forms [3].
                 }
                 else if (p == "explicit_timeout" && value) {
                     this.timeout_length = null;
+                    if (this.timeout_id)
+                    {
+                        clearTimeout(this.timeout_id);
+                    }
                 }
                 else if (p == "timeout_multiplier")
                 {


### PR DESCRIPTION
Doing that prevents things like explicit_timeout to work properly, since
the timeout handler will be installed before setup() has run, which is
when explicit_timeout will be set.

We found out about this while running our testharness.js based tests at Mozilla.  Please see this Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=885878
