### PR TITLE
Fixed IdlInterface.prototype.test_self

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -1075,7 +1075,8 @@ IdlInterface.prototype.test_self = function()
         // value is an object called the interface object.
         // The property has the attributes { [[Writable]]: true,
         // [[Enumerable]]: false, [[Configurable]]: true }."
-        if (this.is_callback() && !this.has_constants()) {
+        if ((this.is_callback() && !this.has_constants())
+        || (!this.is_callback() && this.has_extended_attribute("NoInterfaceObject"))) {
             return;
         }
 


### PR DESCRIPTION
to pass away existence checking of non-callback interface
with [NoInterfaceObject] extended attribute declared.

http://www.w3.org/TR/WebIDL/#es-interfaces
