### PR TITLE
Fail gracefully for callback interfaces

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -317,8 +317,9 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls)
             this.members[parsed_idl.name] = new IdlEnum(parsed_idl);
             break;
 
-        case "callback":
+        case "callback interface":
             // TODO
+            console.log("callback interface not yet supported");
             break;
 
         default:


### PR DESCRIPTION
webidl2.js recognizes the new "callback interface" type.  We should skip these if we find them in an IDL and log a notice to the console, as for other unsupported types, instead of throwing a fatal exception.
