### PR TITLE
Drop IdlEnum.prototype.test function. Not needed.

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -1829,15 +1829,5 @@ function IdlEnum(obj)
 
 IdlEnum.prototype = Object.create(IdlObject.prototype);
 
-IdlEnum.prototype.test = function()
-//@{
-{
-            test(function()
-            {
-		// NOTHING to test
-		return;
-	    });
-}
-//@}
 }());
 // vim: set expandtab shiftwidth=4 tabstop=4 foldmarker=@{,@} foldmethod=marker:


### PR DESCRIPTION
The IdlEnum.prototype.test function isn't necessary. It causes additional
spurious/useless PASS messages in the test results despite the fact it's
not actually testing anything and so nothing is actually passing.
