### PR TITLE
add assert_null and assert_not_null functions

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -668,20 +668,20 @@ policies and contribution forms [3].
 
     function is_null(any)
     {
-        return any === null;
+        return Boolean(!any && typeof(any) != "undefined" && any != 0 && any != "");
     }
 
     function assert_null(actual, description)
     {
-        assert(is_null(actual), "assert_null", description,
-                                "expected null got ${actual}", {actual:actual});
+        assert(is_null(actual) === true, "assert_null", description,
+                                         "expected null got ${actual}", {actual:actual});
     };
     expose(assert_null, "assert_null");
 
     function assert_not_null(actual, description)
     {
-        assert(is_null(actual), "assert_not_null", description,
-                                "expected not null got ${actual}", {actual:actual});
+        assert(is_null(actual) === false, "assert_not_null", description,
+                                          "expected not null got ${actual}", {actual:actual});
     };
     expose(assert_not_null, "assert_not_null");
 


### PR DESCRIPTION
There are many attributes in spec that be initialized to null. Using
these two functions can instead of the repeatly checking statement.
