### PR TITLE
Stringify exceptions thrown from setup().

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1362,13 +1362,11 @@ policies and contribution forms [3].
 
         if (func)
         {
-            try
-            {
+            try {
                 func();
-            } catch(e)
-            {
+            } catch (e) {
                 this.status.status = this.status.ERROR;
-                this.status.message = e;
+                this.status.message = String(e);
             };
         }
         this.set_timeout();


### PR DESCRIPTION
Passing random objects here causes an exception under `map()`, as we try to set `rv.length` to `undefined`.
