### PR TITLE
Exception on testharness_properties access

### DIFF
--- a/testharnessreport.js
+++ b/testharnessreport.js
@@ -387,6 +387,6 @@ try {
     if (window.opener && "testharness_properties" in window.opener) {
         setup(window.opener.testharness_properties);
     }
+} catch (e) {
 }
-catch (e) {}
 // vim: set expandtab shiftwidth=4 tabstop=4:


### PR DESCRIPTION
when opening through a@target window.opener is defined but the SOP can trigger an exception if the origins don't match
