### PR TITLE
Use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "webidl2"]
 	path = webidl2
-	url = git://github.com/darobin/webidl2.js.git
+	url = https://github.com/darobin/webidl2.js.git


### PR DESCRIPTION
Most firewalls block the ports used by git:// remotes. Switching the webidl remote to https:// to make this easier to use.
