### PR TITLE
step_func propagates result, Promise examples

### DIFF
--- a/apisample10.html
+++ b/apisample10.html
@@ -1,0 +1,119 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Async Tests and Promises</title>
+</head>
+<body>
+<h1>Async Tests and Promises</h1>
+<p>This test assumes ECMAScript 6 Promise support. Some failures are expected.</p>
+<div id="log"></div>
+<script src="testharness.js"></script>
+<script src="testharnessreport.js"></script>
+<script>
+
+test(function() {
+  var p = new Promise(function(resolve, reject) {});
+  assert_true('then' in p);
+  assert_equals(typeof Promise.resolve, 'function');
+  assert_equals(typeof Promise.reject, 'function');
+}, "Promises are supported in your browser");
+
+(function() {
+  var t = async_test("Promise resolution");
+  t.step(function() {
+    Promise.resolve('x').then(
+      t.step_func(function(value) {
+        assert_equals(value, 'x');
+        t.done();
+      }),
+      t.unreached_func('Promise should not reject')
+    );
+  });
+}());
+
+(function() {
+  var t = async_test("Promise rejection");
+  t.step(function() {
+    Promise.reject(Error('fail')).then(
+      t.unreached_func('Promise should reject'),
+      t.step_func(function(reason) {
+        assert_true(reason instanceof Error);
+        assert_equals(reason.message, 'fail');
+        t.done();
+      })
+    );
+  });
+}());
+
+(function() {
+  var t = async_test("Promises resolution chaining");
+  t.step(function() {
+    var resolutions = [];
+    Promise.resolve('a').then(
+      t.step_func(function(value) {
+        resolutions.push(value);
+        return 'b';
+      })
+    ).then(
+      t.step_func(function(value) {
+        resolutions.push(value);
+        return 'c';
+      })
+    ).then(
+      t.step_func(function(value) {
+        resolutions.push(value);
+
+        assert_array_equals(resolutions, ['a', 'b', 'c']);
+        t.done();
+      })
+    ).catch(
+      t.unreached_func('promise should not have rejected')
+    );
+  });
+}());
+
+(function() {
+  var t = async_test("Use of step_func with Promises");
+  t.step(function() {
+    var resolutions = [];
+    Promise.resolve('x').then(
+      t.step_func_done(),
+      t.unreached_func('Promise should not have rejected')
+    );
+  });
+}());
+
+(function() {
+  var t = async_test("Promises and test assertion failures (should fail)");
+  t.step(function() {
+    var resolutions = [];
+    Promise.resolve('x').then(
+      t.step_func(function(value) {
+        assert_true(false, 'This failure is expected');
+      })
+    ).then(
+      t.unreached_func('Promise should not have resolved')
+    ).catch(
+      t.unreached_func('Promise should not have rejected')
+    );
+  });
+}());
+
+(function() {
+  var t = async_test("Use of unreached_func with Promises (should fail)");
+  t.step(function() {
+    var resolutions = [];
+    var r;
+    var p = new Promise(function(resolve, reject) {
+      // Reject instead of resolve, to demonstrate failure.
+      reject(123);
+    });
+    p.then(
+      function(value) {
+        assert_equals(value, 123, 'This should not actually happen');
+      },
+      t.unreached_func('This failure is expected')
+    );
+  });
+}());
+</script>

--- a/testharness.js
+++ b/testharness.js
@@ -119,6 +119,11 @@ policies and contribution forms [3].
  *
  * object.some_event = t.step_func(function(e) {assert_true(e.a)});
  *
+ * For asynchronous callbacks that should never execute, unreached_func can
+ * be used. For example:
+ *
+ * object.some_event = t.unreached_func("some_event should not fire");
+ *
  * == Single Page Tests ==
  *
  * Sometimes, particularly when dealing with asynchronous behaviour,
@@ -1231,7 +1236,7 @@ policies and contribution forms [3].
 
         return function()
         {
-            test_this.step.apply(test_this, [func, this_obj].concat(
+            return test_this.step.apply(test_this, [func, this_obj].concat(
                 Array.prototype.slice.call(arguments)));
         };
     };
@@ -1252,6 +1257,29 @@ policies and contribution forms [3].
             }
             test_this.done();
         };
+    };
+
+    Test.prototype.unreached_func = function(description, this_obj)
+    {
+        var test_this = this;
+
+        if (arguments.length === 1) {
+            this_obj = test_this;
+        }
+
+        return function()
+        {
+            test_this.step.call(test_this, function() {
+                assert_unreached(description);
+            });
+        };
+    };
+
+    Test.prototype.unreached_func = function(description)
+    {
+        return this.step_func(function() {
+            assert_unreached(description);
+        });
     };
 
     Test.prototype.add_cleanup = function(callback) {


### PR DESCRIPTION
In async tests, using testharness.js effectively requires that callbacks are wrapped with `step_func()` calls so that assertion failures are caught by the test harness. Promise chaining requires that the callbacks return values, so `step_func()` needs to return the value returned by the wrap function, in normal cases.

This adds some examples of Promise functionality (assuming ES6 promise support in your browser) and the `step_func` fix.
