### PR TITLE
Add support for DOMTimeStamp and DOMHighResTimeStamp to idlharness.js

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -413,12 +413,14 @@ IdlArray.prototype.assert_type_is = function(value, type)
             return;
 
         case "unsigned long long":
+        case "DOMTimeStamp":
             assert_equals(typeof value, "number");
             assert_true(0 <= value, "unsigned long long is negative");
             return;
 
         case "float":
         case "double":
+        case "DOMHighResTimeStamp":
         case "unrestricted float":
         case "unrestricted double":
             // TODO: distinguish these cases


### PR DESCRIPTION
Per:
http://www.w3.org/TR/DOM-Level-3-Core/core.html#Core-DOMTimeStamp
and:
http://www.w3.org/TR/hr-time/#sec-DOMHighResTimeStamp

This should work fine. This is annoying me because Gamepad has a DOMHighResTimeStamp propery.
