### PR TITLE
Add EventWatcher helper to testharness.js

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -147,6 +147,42 @@ with a TypeError:
       return promise_rejects(t, new TypeError(), bar);
     }, "Another example");
 
+`EventWatcher` is a constructor function that allows DOM events to be handled
+using Promises, which can make it a lot easier to test a very specific series
+of events, including ensuring that unexpected events are not fired at any point.
+
+Here's an example of how to use `EventWatcher`:
+
+    var t = async_test("Event order on animation start");
+
+    var animation = watchedNode.getAnimations()[0];
+    var eventWatcher = new EventWatcher(watchedNode, ['animationstart',
+                                                      'animationiteration',
+                                                      'animationend']);
+
+    eventWatcher.wait_for(t, 'animationstart').then(t.step_func(function() {
+      assertExpectedStateAtStartOfAnimation();
+      animation.currentTime = END_TIME; // skip to end
+      // We expect two animationiteration events then an animationend event on
+      // skipping to the end of the animation.
+      return eventWatcher.wait_for(['animationiteration',
+                                    'animationiteration',
+                                    'animationend']);
+    })).then(t.step_func(function() {
+      assertExpectedStateAtEndOfAnimation();
+      test.done();
+    }));
+
+`wait_for` either takes the name of a single event and returns a Promise that
+will resolve after that event is fired at the watched node, or else it takes an
+array of the names of a series of events and returns a Promise that will
+resolve after that specific series of events has been fired at the watched node.
+
+`EventWatcher` will assert if an event occurs while there is no `wait_for`()
+created Promise waiting to be fulfilled, or if the event is of a different type
+to the type currently expected. This ensures that only the events that are
+expected occur, in the correct order, and with the correct timing.
+
 ## Single Page Tests ##
 
 Sometimes, particularly when dealing with asynchronous behaviour,

--- a/testharness.js
+++ b/testharness.js
@@ -470,6 +470,73 @@ policies and contribution forms [3].
         });
     }
 
+    /**
+     * This constructor helper allows DOM events to be handled using Promises,
+     * which can make it a lot easier to test a very specific series of events,
+     * including ensuring that unexpected events are not fired at any point.
+     */
+    function EventWatcher(test, watchedNode, eventTypes)
+    {
+        if (typeof eventTypes == 'string') {
+            eventTypes = [eventTypes];
+        }
+
+        var waitingFor = null;
+
+        var eventHandler = test.step_func(function(evt) {
+            assert_true(!!waitingFor,
+                        'Not expecting event, but got ' + evt.type + ' event');
+            assert_equals(evt.type, waitingFor.types[0],
+                          'Expected ' + waitingFor.types[0] + ' event, but got ' +
+                          evt.type + ' event instead');
+            if (waitingFor.types.length > 1) {
+                // Pop first event from array
+                waitingFor.types.shift();
+                return;
+            }
+            // We need to null out waitingFor before calling the resolve function
+            // since the Promise's resolve handlers may call wait_for() which will
+            // need to set waitingFor.
+            var resolveFunc = waitingFor.resolve;
+            waitingFor = null;
+            resolveFunc(evt);
+        });
+
+        for (var i = 0; i < eventTypes.length; i++) {
+            watchedNode.addEventListener(eventTypes[i], eventHandler);
+        }
+
+        /**
+         * Returns a Promise that will resolve after the specified event or
+         * series of events has occured.
+         */
+        this.wait_for = function(types) {
+            if (waitingFor) {
+                return Promise.reject('Already waiting for an event or events');
+            }
+            if (typeof types == 'string') {
+                types = [types];
+            }
+            return new Promise(function(resolve, reject) {
+                waitingFor = {
+                    types: types,
+                    resolve: resolve,
+                    reject: reject
+                };
+            });
+        };
+
+        function stop_watching() {
+            for (var i = 0; i < eventTypes.length; i++) {
+                watchedNode.removeEventListener(eventTypes[i], eventHandler);
+            }
+        };
+
+        test.add_cleanup(stop_watching);
+
+        return this;
+    }
+
     function setup(func_or_properties, maybe_properties)
     {
         var func = null;


### PR DESCRIPTION
It is very difficult to test that a series of events occurs in a very specific
order, while also checking that unexpected events do not occur between any of
the expected events. This helper can create Promises that resolve when the
expected events occur, and reject when unexpected events occur, which makes
the process of testing such events much more feasible.

This constructor is already being used is Mozilla code, and this patch upstreams its implementation.

https://mxr.mozilla.org/mozilla-central/search?string=EventWatcher&find=dom%2Fanimation&findi=&filter=^[^\0]*%24&hitlimit=&tree=mozilla-central

It has been very successful at allowing test coverage to be created where it otherwise would have been skipped, and we plan to start making much more significant use of it going forward.