### PR TITLE
Don't error out trying to access cross-origin functions when document.domain got set.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -71,13 +71,22 @@ policies and contribution forms [3].
 
     WindowTestEnvironment.prototype._dispatch = function(selector, callback_args, message_arg) {
         this._forEach_windows(
-                function(w, is_same_origin) {
-                    if (is_same_origin && selector in w) {
+                function(w, same_origin) {
+                    if (same_origin) {
                         try {
-                            w[selector].apply(undefined, callback_args);
-                        } catch (e) {
-                            if (debug) {
-                                throw e;
+                            var has_selector = selector in w;
+                        } catch(e) {
+                            // If document.domain was set at some point same_origin can be
+                            // wrong and the above will fail.
+                            has_selector = false;
+                        }
+                        if (has_selector) {
+                            try {
+                                w[selector].apply(undefined, callback_args);
+                            } catch (e) {
+                                if (debug) {
+                                    throw e;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Setting document.domain changes the origin of the current document to be different
to the origin it had before. This invalidates the cache of origins, so in this case
we need to catch the error and make sure we don't try to call a cross-origin function.