### PR TITLE
Define setup_default_test_properties.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -563,6 +563,14 @@ policies and contribution forms [3].
         test_environment.on_new_harness_properties(properties);
     }
 
+    function setup_default_test_properties(properties)
+    {
+        if (typeof properties !== "object") {
+            throw new Error("Default test properties should be an object and it is " + typeof properties);
+        }
+        tests.default_test_properties = properties;
+    }
+
     function done() {
         if (tests.tests.length === 0) {
             tests.set_file_is_test();
@@ -597,6 +605,7 @@ policies and contribution forms [3].
     expose(promise_rejects, 'promise_rejects');
     expose(generate_tests, 'generate_tests');
     expose(setup, 'setup');
+    expose(setup_default_test_properties, 'setup_default_test_properties');
     expose(done, 'done');
     expose(on_event, 'on_event');
 
@@ -1228,6 +1237,12 @@ policies and contribution forms [3].
         this.index = null;
 
         this.properties = properties;
+        for (var attr in tests.default_test_properties) {
+            if (!(attr in this.properties)) {
+                this.properties[attr] = tests.default_test_properties[attr];
+            }
+        }
+
         var timeout = properties.timeout ? properties.timeout : settings.test_timeout;
         if (timeout !== null) {
             this.timeout_length = timeout * tests.timeout_multiplier;
@@ -1604,6 +1619,7 @@ policies and contribution forms [3].
         this.phase = this.phases.INITIAL;
 
         this.properties = {};
+        this.default_test_properties = {};
 
         this.wait_for_finish = false;
         this.processing_callbacks = false;


### PR DESCRIPTION
This allows a set of tests to share a common set of properties without
having to pass all the tests the same options.