### PR TITLE
Fix AssertionError.get_stack for IE

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -2335,7 +2335,15 @@ policies and contribution forms [3].
     AssertionError.prototype = Object.create(Error.prototype);
 
     AssertionError.prototype.get_stack = function() {
-        var lines = new Error().stack.split("\n");
+        var stack = new Error().stack;
+        if (!stack) {
+            try {
+                throw new Error();
+            } catch (e) {
+                stack = e.stack;
+            }
+        }
+        var lines = stack.split("\n");
         var rv = [];
         var re = /\/resources\/testharness\.js/;
         var i = 0;


### PR DESCRIPTION
IE does not set Error.stack until it's thrown, so all fail messages show the stack for get_stack. This patch shows the correct stack traces for such UAs.