### PR TITLE
Fix handling of assertions in workers

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -2542,8 +2542,9 @@ policies and contribution forms [3].
     /** Returns the 'src' URL of the first <script> tag in the page to include the file 'testharness.js'. */
     function get_script_url()
     {
-        if (!('document' in self))
+        if (!('document' in self)) {
             return undefined;
+        }
 
         var scripts = document.getElementsByTagName("script");
         for (var i = 0; i < scripts.length; i++) {

--- a/testharness.js
+++ b/testharness.js
@@ -2429,7 +2429,7 @@ policies and contribution forms [3].
 
         // Create a pattern to match stack frames originating within testharness.js.  These include the
         // script URL, followed by the line/col (e.g., '/resources/testharness.js:120:21').
-        var re = new RegExp(get_script_url() + ":\\d+:\\d+");
+        var re = new RegExp((get_script_url() || "\\btestharness.js") + ":\\d+:\\d+");
 
         // Some browsers include a preamble that specifies the type of the error object.  Skip this by
         // advancing until we find the first stack frame originating from testharness.js.
@@ -2542,6 +2542,9 @@ policies and contribution forms [3].
     /** Returns the 'src' URL of the first <script> tag in the page to include the file 'testharness.js'. */
     function get_script_url()
     {
+        if (!('document' in self))
+            return undefined;
+
         var scripts = document.getElementsByTagName("script");
         for (var i = 0; i < scripts.length; i++) {
             var src;


### PR DESCRIPTION
Don't try and compute the path for testharness.js by looking at script tags in workers - that's not gonna work. Instead, give up and fall back to a simple hardcoded regex.

Not pretty, but it fixes https://github.com/w3c/testharness.js/issues/134 and the repro in https://github.com/w3c/testharness.js/issues/129 is still fixed.