### PR TITLE
Move apisamples to examples directory.

### DIFF
--- a/examples/apisample-error-worker.js
+++ b/examples/apisample-error-worker.js
@@ -1,3 +1,3 @@
-importScripts("testharness.js");
+importScripts("../testharness.js");
 
 throw new Error("This failure is expected.");

--- a/examples/apisample-worker.js
+++ b/examples/apisample-worker.js
@@ -1,4 +1,4 @@
-importScripts("testharness.js");
+importScripts("../testharness.js");
 
 test(
     function(test) {

--- a/examples/apisample.htm
+++ b/examples/apisample.htm
@@ -7,8 +7,8 @@
 <body onload="load_test_attr.done()">
 <h1>Sample HTML5 API Tests</h1>
 <div id="log"></div>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
     setup_run = false;
     setup(function() {

--- a/examples/apisample10.html
+++ b/examples/apisample10.html
@@ -7,8 +7,8 @@
 <h1>Async Tests and Promises</h1>
 <p>This test assumes ECMAScript 6 Promise support. Some failures are expected.</p>
 <div id="log"></div>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 
 test(function() {

--- a/examples/apisample11.html
+++ b/examples/apisample11.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Example with iframe that notifies containing document via callbacks</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 </head>
 <body onload="start_test_in_iframe()">
 <h1>Callbacks From Tests Running In An IFRAME</h1>

--- a/examples/apisample12.html
+++ b/examples/apisample12.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Example with iframe that notifies containing document via cross document messaging</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 </head>
 <body>
 <h1>Notifications From Tests Running In An IFRAME</h1>

--- a/examples/apisample13.html
+++ b/examples/apisample13.html
@@ -8,8 +8,8 @@
 <p>This test demonstrates the use of <tt>promise_test</tt>. Assumes ECMAScript 6
 Promise support. Some failures are expected.</p>
 <div id="log"></div>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 test(
     function() {

--- a/examples/apisample14.html
+++ b/examples/apisample14.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Dedicated Worker Tests</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 </head>
 <body>
 <h1>Dedicated Web Worker Tests</h1>

--- a/examples/apisample15.html
+++ b/examples/apisample15.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Example with a shared worker</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 </head>
 <body>
 <h1>Shared Web Worker Tests</h1>

--- a/examples/apisample16.html
+++ b/examples/apisample16.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Example with a service worker</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 </head>
 <body>
 <h1>Service Worker Tests</h1>

--- a/examples/apisample2.htm
+++ b/examples/apisample2.htm
@@ -7,8 +7,8 @@
 <h1>Sample HTML5 API Tests</h1>
 <p>There should be two results</p>
 <div id="log"></div>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 setup({explicit_done:true})
 test(function() {assert_true(true)}, "Test defined before onload");

--- a/examples/apisample3.htm
+++ b/examples/apisample3.htm
@@ -3,7 +3,7 @@
 <head>
 <title>Sample HTML5 API Tests</title>
 </head>
-<script src="testharness.js"></script>
+<script src="../testharness.js"></script>
 
 <body onload="load_test_attr.done()">
 <h1>Sample HTML5 API Tests</h1>

--- a/examples/apisample4.htm
+++ b/examples/apisample4.htm
@@ -3,7 +3,7 @@
 <head>
 <title>Harness Handling Uncaught Exception</title>
 </head>
-<script src="testharness.js"></script>
+<script src="../testharness.js"></script>
 
 <body>
 <h1>Harness Handling Uncaught Exception</h1>

--- a/examples/apisample5.htm
+++ b/examples/apisample5.htm
@@ -3,7 +3,7 @@
 <head>
 <title>Harness Ignoring Uncaught Exception</title>
 </head>
-<script src="testharness.js"></script>
+<script src="../testharness.js"></script>
 
 <body>
 <h1>Harness Ignoring Uncaught Exception</h1>

--- a/examples/apisample6.html
+++ b/examples/apisample6.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 onload = function() {
   assert_true(true);

--- a/examples/apisample7.html
+++ b/examples/apisample7.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test (should fail)</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 onload = function() {
   assert_true(false);

--- a/examples/apisample8.html
+++ b/examples/apisample8.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no body</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 assert_true(true);
 done();

--- a/examples/apisample9.html
+++ b/examples/apisample9.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no asserts</title>
-<script src="testharness.js"></script>
-<script src="testharnessreport.js"></script>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
 <script>
 done();
 </script>


### PR DESCRIPTION
Reduce clutter in top-level directory. https://github.com/w3c/testharness.js/issues/137