### PR TITLE
assert_object_equals: Check property ownership

### DIFF
--- a/examples/apisample.htm
+++ b/examples/apisample.htm
@@ -167,9 +167,18 @@
     test(function() {assert_equals(window.global, undefined)},
          "Test that cleanup handlers from previous test ran");
 
+    test(function() {
+      var a = Object.setPrototypeOf({p: 1}, {q: 2});
+      var b = Object.setPrototypeOf({p: 1}, {q: 2});
+      assert_object_equals(a, b, "properties on object and prototypes are compared");
+    }, "assert_object_equals handles properties on prototype chain");
+
+    test(function() {
+      var a = Object.setPrototypeOf({p: 1}, {q: 2});
+      var b = {p: 1, q: 2};
+      assert_object_equals(a, b, "property ownership differences cause failure");
+    }, "assert_object_equals - expected to fail");
+
 </script>
 </body>
 </html>
-
-
-

--- a/testharness.js
+++ b/testharness.js
@@ -891,8 +891,9 @@ policies and contribution forms [3].
 
              var p;
              for (p in actual) {
-                 assert(expected.hasOwnProperty(p), "assert_object_equals", description,
-                                                    "unexpected property ${p}", {p:p});
+                 assert(expected.hasOwnProperty(p) === actual.hasOwnProperty(p),
+                        "assert_object_equals", description,
+                        "unexpected property ${p}", {p:p});
 
                  if (typeof actual[p] === "object" && actual[p] !== null) {
                      if (stack.indexOf(actual[p]) === -1) {
@@ -905,7 +906,7 @@ policies and contribution forms [3].
                  }
              }
              for (p in expected) {
-                 assert(actual.hasOwnProperty(p),
+                 assert(actual.hasOwnProperty(p) === expected.hasOwnProperty(p),
                         "assert_object_equals", description,
                         "expected property ${p} missing", {p:p});
              }


### PR DESCRIPTION
Rather than asserting that all enumerated properties are own properties, confirm that properties have the same own-ness.

This allows assert_object_equals() to be used to compare DOM objects, where properties are exposed via getters on the prototype.