### PR TITLE
Simplify legacycaller detection.

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -1286,15 +1286,10 @@ IdlInterface.prototype.test_object = function(desc)
         exception = e;
     }
 
-    // TODO: WebIDLParser doesn't currently support named legacycallers, so I'm
-    // not sure what those would look like in the AST
-    var expected_typeof = this.members.some(function(member)
-    {
-        return member.legacycaller
-            || ("idlType" in member && member.idlType.legacycaller)
-            || ("idlType" in member && typeof member.idlType == "object"
-            && "idlType" in member.idlType && member.idlType.idlType == "legacycaller");
-    }) ? "function" : "object";
+    var expected_typeof =
+        this.members.some(function(member) { return member.legacycaller; })
+        ? "function"
+        : "object";
 
     this.test_primary_interface_of(desc, obj, exception, expected_typeof);
     var current_interface = this;


### PR DESCRIPTION
WebIDLParser now supports it, with a boolean legacycaller member.