### PR TITLE
Issue #157: DOM hierarchy error with XHTML and SVG

### DIFF
--- a/testharnessreport.js
+++ b/testharnessreport.js
@@ -395,7 +395,14 @@ function dump_test_results(tests, status) {
             message: status.message,
             stack: status.stack};
     results_element.textContent = JSON.stringify(data);
-    document.documentElement.lastChild.appendChild(results_element);
+
+    // To avoid a HierarchyRequestError with XML documents, ensure that 'results_element'
+    // is inserted at a location that results in a valid document.
+    var parent = document.body
+        ? document.body                 // <body> is required in XHTML documents
+        : document.documentElement;     // fallback for optional <body> in HTML5, SVG, etc.
+
+    parent.appendChild(results_element);
 }
 
 metadata_generator.setup();

--- a/testharnessreport.js
+++ b/testharnessreport.js
@@ -389,11 +389,11 @@ function dump_test_results(tests, status) {
     var test_results = tests.map(function(x) {
         return {name:x.name, status:x.status, message:x.message, stack:x.stack}
     });
-    data = {test:window.location.href,
-            tests:test_results,
-            status: status.status,
-            message: status.message,
-            stack: status.stack};
+    var data = {test:window.location.href,
+                tests:test_results,
+                status: status.status,
+                message: status.message,
+                stack: status.stack};
     results_element.textContent = JSON.stringify(data);
 
     // To avoid a HierarchyRequestError with XML documents, ensure that 'results_element'

--- a/testharnessreport.js
+++ b/testharnessreport.js
@@ -1,4 +1,6 @@
-/*global add_completion_callback, setup */
+/* global add_completion_callback */
+/* global setup */
+
 /*
  * This file is intended for vendors to implement
  * code needed to integrate testharness.js tests with their own test systems.
@@ -22,8 +24,6 @@
  * For more documentation about the callback functions and the
  * parameters they are called with see testharness.js
  */
-
-
 
 var metadata_generator = {
 


### PR DESCRIPTION
dump_test_results() would throw a DOM hierarchy error for xhtml/svg documents if the '.lastChild' happened to be one that can not accept the 'results_element'.

A couple of additional opportunistic tweaks:
  - Fixed accidental use of the global 'data'.
  - Separated /* global */ declarations so VS Code can understand them.