### PR TITLE
Issue #159: First promise_test() should not defer invoking 'func'

### DIFF
--- a/examples/apisample13.html
+++ b/examples/apisample13.html
@@ -20,6 +20,16 @@ test(
     },
     "Promises are supported in your browser");
 
+var promise_created_synchronously = true;
+promise_test(function (test) {
+    return new Promise(function (accept, reject) {
+        assert_true(promise_created_synchronously,
+            "Promise must be created synchronously at the time 'promise_test()' was invoked.");
+        accept();
+    });
+}, "First 'promise_test()' must not be deferred.");
+promise_created_synchronously = false;
+
 promise_test(
     function() {
         return Promise.resolve("x")


### PR DESCRIPTION
The fix is to simply initialize the chain of 'promise_tests' with the Promise
created by the first call to promise_test().  Previously, the first
promise_test() was chained to a pre-resolved Promise.

(Even though the Promise was resolved, Promise semantics still defer the
.then() callback.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/162)
<!-- Reviewable:end -->
