### PR TITLE
Function to add a cleanup function to every test in the file.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -283,6 +283,26 @@ test(function() {
      });
 ```
 
+Sometimes you need to run the same cleanup function for each of your tests. In
+this case you can call `tests_cleanup()` at the top of your test file to add a
+clean up function to each tests. For example
+
+```js
+tests_cleanup(function() {delete window.some_global});
+
+test(function() {
+         window.some_global = "example1";
+         assert_true(false);
+     });
+
+test(function() {
+         window.some_global = "example2";
+         assert_true(false);
+     });
+```
+
+In the example above `window.some_global` will be deleted after each test.
+
 ## Timeouts in Tests ##
 
 In general the use of timeouts in tests is discouraged because this is

--- a/testharness.js
+++ b/testharness.js
@@ -1811,6 +1811,9 @@ policies and contribution forms [3].
 
     Tests.prototype.push = function(test)
     {
+        if (this.tests_cleanup) {
+          test.add_cleanup(this.tests_cleanup);
+        }
         if (this.phase < this.phases.HAVE_TESTS) {
             this.start();
         }
@@ -1916,6 +1919,11 @@ policies and contribution forms [3].
         tests.fetch_tests_from_worker(port);
     }
     expose(fetch_tests_from_worker, 'fetch_tests_from_worker');
+
+    function tests_cleanup(func) {
+      tests.tests_cleanup = func;
+    }
+    expose(tests_cleanup, 'tests_cleanup');
 
     function timeout() {
         if (tests.timeout_length === null) {


### PR DESCRIPTION
In Web Bluetooth tests we would like to run the same clean up function after each test. Using `test.add_cleanup()` in each test is very tedious and error prone. The function added in this PR allows developers to easily add the same cleanup function to all their tests.

@scheib @jyasskin @inexorabletash 