### PR TITLE
add checking of WorkerGlobalScope for DedicatedWorkerGlobalScope

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -471,6 +471,11 @@ policies and contribution forms [3].
             self instanceof ServiceWorkerGlobalScope) {
             return new ServiceWorkerTestEnvironment();
         }
+        if ('WorkerGlobalScope' in self &&
+            self instanceof WorkerGlobalScope) {
+            return new DedicatedWorkerTestEnvironment();
+        }
+        
         throw new Error("Unsupported test environment");
     }
 


### PR DESCRIPTION
Fixes #173. 

The change is just add 'WorkerGlobalScope' type name for creating DedicatedWorkerGlobalScope. 

It could be possible to add checking together in the line of 'DedicatedWorkerGlobalScope', but that could unnecessarily run for Shared/Service worker case that isn't desirable for supporting Edge only case.