### PR TITLE
Getters on a global without an explicit this should throw TypeError (…

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -1071,8 +1071,9 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 gotValue = false;
             }
             if (gotValue) {
-                assert_equals(propVal, getter.call(undefined),
-                              "Gets on a global should not require an explicit this");
+                assert_throws(new TypeError(), function() {
+                    getter.call(undefined);
+                }, "Gets on a global without an explicit this should throw TypeError");
             }
 
             this.do_interface_attribute_asserts(self, member);


### PR DESCRIPTION
…closes #182)

Getters on a global without an explicit this should throw TypeError as per:
- http://heycam.github.io/webidl/#dfn-attribute-getter
- http://heycam.github.io/webidl/#ImplicitThis

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/183)
<!-- Reviewable:end -->
