### PR TITLE
Add description parameter to promise_rejects.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -160,7 +160,7 @@ previous Promise Test finishes.
 `promise_rejects` can be used to test Promises that need to reject:
 
 ```js
-promise_rejects(test_object, code, promise)
+promise_rejects(test_object, code, promise, description)
 ```
 
 The `code` argument is equivalent to the same argument to the `assert_throws`

--- a/testharness.js
+++ b/testharness.js
@@ -540,9 +540,9 @@ policies and contribution forms [3].
         });
     }
 
-    function promise_rejects(test, expected, promise) {
-        return promise.then(test.unreached_func("Should have rejected.")).catch(function(e) {
-            assert_throws(expected, function() { throw e });
+    function promise_rejects(test, expected, promise, description) {
+        return promise.then(test.unreached_func("Should have rejected: " + description)).catch(function(e) {
+            assert_throws(expected, function() { throw e }, description);
         });
     }
 


### PR DESCRIPTION
All assert methods take a description parameter, so for consistency also
add one to promise_rejects.

This fixes #190