### PR TITLE
Fix typo in promise_rejects example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -202,7 +202,7 @@ function bar() {
 }
 
 promise_test(function(t) {
-  return promise_rejects(t, new TypeError(), bar);
+  return promise_rejects(t, new TypeError(), bar());
 }, "Another example");
 ```
 


### PR DESCRIPTION
The promise_rejects function expects a Promise as third argument, not a function. The "bar" function needs to be called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/206)
<!-- Reviewable:end -->
