### PR TITLE
Make HTTPS tests fail if they are loaded over HTTP

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -489,6 +489,19 @@ policies and contribution forms [3].
         return 'ServiceWorker' in self && worker instanceof ServiceWorker;
     }
 
+    function enforce_https() {
+        var pos = 0;
+        if (location && location.pathname) {
+            pos = location.pathname.indexOf(".https.html");
+            if ((pos !== -1) &&
+                (pos === (location.pathname.length - ".https.html".length)) &&
+                (location.protocol !== "https:")) {
+                assert(false, "enforce_https", "Test page must be loaded over HTTPS.",
+                        "Protocol is ${protocol}", {protocol:location.protocol});
+            }
+        }
+    }
+
     /*
      * API functions
      */
@@ -498,6 +511,7 @@ policies and contribution forms [3].
         var test_name = name ? name : test_environment.next_default_test_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
+        test_obj.step(enforce_https, test_obj, test_obj);
         test_obj.step(func, test_obj, test_obj);
         if (test_obj.phase === test_obj.phases.STARTED) {
             test_obj.done();
@@ -514,6 +528,7 @@ policies and contribution forms [3].
         var test_name = name ? name : test_environment.next_default_test_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
+        test_obj.step(enforce_https, test_obj, test_obj);
         if (func) {
             test_obj.step(func, test_obj, test_obj);
         }


### PR DESCRIPTION
The goal of this PR is to make the test harness fail HTTPS-only tests when they are loaded over HTTP with a "Test page must be loaded over HTTPS" message.

The assumption is that such tests are defined in files that end with `.https.html`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/207)

<!-- Reviewable:end -->
