### PR TITLE
Don't call test.step for promise_tests too soon.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -523,11 +523,9 @@ policies and contribution forms [3].
     function promise_test(func, name, properties) {
         var test = async_test(name, properties);
         // If there is no promise tests queue make one.
-        test.step(function() {
-            if (!tests.promise_tests) {
-                tests.promise_tests = Promise.resolve();
-            }
-        });
+        if (!tests.promise_tests) {
+            tests.promise_tests = Promise.resolve();
+        }
         tests.promise_tests = tests.promise_tests.then(function() {
             return Promise.resolve(test.step(func, test, test))
                 .then(


### PR DESCRIPTION
Calling test.step starts the timeout for the test, for promise tests this
shouldn't happen until the the previous promise_test finished, and the
current test is actually being started. Not sure if there was some other
reason for the test.step call here though.

This fixes #208

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/209)
<!-- Reviewable:end -->
