### PR TITLE
Fixed example code of EventWatcher, we will need to specify the test object in constructor.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -216,11 +216,11 @@ Here's an example of how to use `EventWatcher`:
 var t = async_test("Event order on animation start");
 
 var animation = watchedNode.getAnimations()[0];
-var eventWatcher = new EventWatcher(watchedNode, ['animationstart',
-                                                  'animationiteration',
-                                                  'animationend']);
+var eventWatcher = new EventWatcher(t, watchedNode, ['animationstart',
+                                                     'animationiteration',
+                                                     'animationend']);
 
-eventWatcher.wait_for(t, 'animationstart').then(t.step_func(function() {
+eventWatcher.wait_for('animationstart').then(t.step_func(function() {
   assertExpectedStateAtStartOfAnimation();
   animation.currentTime = END_TIME; // skip to end
   // We expect two animationiteration events then an animationend event on


### PR DESCRIPTION
The example of api document showed that we specify the Test object when call the wait_for function. But current implementation take Test object in the constructor. 

https://github.com/w3c/testharness.js/blob/master/testharness.js#L557

So I think that we will need to modify this example code.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/210)

<!-- Reviewable:end -->
