### PR TITLE
Make assert_throws('TypeError') work.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1247,13 +1247,20 @@ policies and contribution forms [3].
                 ReadOnlyError: 0,
                 VersionError: 0,
                 OperationError: 0,
+
+                // JS built-in errors:
+                TypeError: 0,
             };
 
             if (!(name in name_code_map)) {
                 throw new AssertionError('Test bug: unrecognized DOMException code "' + code + '" passed to assert_throws()');
             }
 
-            var required_props = { code: name_code_map[name] };
+            var required_props = {};
+            if (name !== 'TypeError') {
+              // DOMExceptions should have a .code member.
+              required_props.code = name_code_map[name];
+            }
 
             if (required_props.code === 0 ||
                (typeof e == "object" &&


### PR DESCRIPTION
Do you want me to add the other native errors listed at https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard in this patch too?

Fixes #62 

@sof @jgraham

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/211)

<!-- Reviewable:end -->
