### PR TITLE
Make get_stack() cope with `Error.stack` not being supported

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -2463,6 +2463,11 @@ policies and contribution forms [3].
             }
         }
 
+        // 'Error.stack' is not supported in all browsers/versions
+        if (!stack) {
+            return "(Stack trace unavailable)";
+        }
+
         var lines = stack.split("\n");
 
         // Create a pattern to match stack frames originating within testharness.js.  These include the


### PR DESCRIPTION
For increased compatibility, particularly with old browser versions.

Additionally, this property doesn't appear to be spec'd anywhere, and having a hard requirement on a non-standard API feels wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/214)
<!-- Reviewable:end -->
