### PR TITLE
Add "NotAllowedError" to the list of DOMException names

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1247,6 +1247,7 @@ policies and contribution forms [3].
                 ReadOnlyError: 0,
                 VersionError: 0,
                 OperationError: 0,
+                NotAllowedError: 0
             };
 
             if (!(name in name_code_map)) {


### PR DESCRIPTION
"NotAllowedError" is defined in WebIDL Editor's Draft:
https://heycam.github.io/webidl/#notallowederror

The error is used in the Presentation API specification in particular:
https://w3c.github.io/presentation-api/#terminology

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/216)
<!-- Reviewable:end -->
