### PR TITLE
EventWatcher: reject waitingFor promise during test cleanup.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -613,6 +613,11 @@ policies and contribution forms [3].
             for (var i = 0; i < eventTypes.length; i++) {
                 watchedNode.removeEventListener(eventTypes[i], eventHandler, false);
             }
+
+            if (waitingFor) {
+                waitingFor.reject(new Error('Test ended while waiting for event'));
+                waitingFor = null;
+            }
         };
 
         test.add_cleanup(stop_watching);


### PR DESCRIPTION
EventWatcher installs a test cleanup function that removes its event listeners. For this reason, if the EventWatcher's wait_for created a promise that is still pending when the test ends, the promise will never be resolved or rejected.

This omission turns into a problem when the EventWatcher's wait_for promise ends up in the promise chain used by promise_test. If an assertion fails in a step() callback, the test's done() method is called, which cleans up the EventWatcher's listener. So, a failure in a single promise_test can block the whole promise chain and prevent all subsequent tests from running.

This commit fixes the issue described above by having any pending EventWatcher promise get rejected when the event listeners get removed.

Test case below. If `assert_true(false` is replaced with `assert_true(true`, both tests pass cleanly. With this PR, the first test fails and the second test passes. Without the PR, the first test times out and the second test never gets to run.

```html
<!doctype html>
<script src="testharness.js"></script>
<script src="testharnessreport.js"></script>
<script>

promise_test(t => new Promise((resolve, reject) => {
  const waiter = (new EventWatcher(t, window, 'message')).wait_for('message');

  t.step(() => assert_true(false, 'AssertionError in Test.step() callback'));

  window.postMessage('Move to the next test', '*');
  resolve(waiter);
}), 'First promise test');

promise_test(() => Promise.resolve(), 'Second promise test');

</script>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/225)
<!-- Reviewable:end -->
