### PR TITLE
Unblock test promise chain when done() is called early.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -527,12 +527,14 @@ policies and contribution forms [3].
             tests.promise_tests = Promise.resolve();
         }
         tests.promise_tests = tests.promise_tests.then(function() {
+            var donePromise = new Promise(function(resolve) {
+                test.add_cleanup(resolve);
+            });
             var promise = test.step(func, test, test);
             test.step(function() {
                 assert_not_equals(promise, undefined);
             });
-            return Promise.resolve(promise)
-                .then(
+            Promise.resolve(promise).then(
                     function() {
                         test.done();
                     })
@@ -544,6 +546,7 @@ policies and contribution forms [3].
                         assert(false, "promise_test", null,
                                "Unhandled rejection with value: ${value}", {value:value});
                     }));
+            return donePromise;
         });
     }
 


### PR DESCRIPTION
This makes it possible to end a promise_test by calling Test.done(). Previously, that would work for a single test, but would get any follow-up test stuck waiting for the global promise chain to resolve.

Test case below. Without the patch, the first test times out and the second test passes. With the patch, both tests pass.

```html
<!doctype html>
<script src="testharness.js"></script>
<script src="testharnessreport.js"></script>
<script>

promise_test(t => new Promise((resolve, reject) => {
  t.done();
}), 'First promise test');

promise_test(() => Promise.resolve(), 'Second promise test');

</script>
```

Credit: The fix does not belong to me. I implemented the solution proposed in https://github.com/w3c/testharness.js/pull/225#issuecomment-266601274

Question: should the race promise reject and complain that Test.done() was called in a promise_test before the test's promise resolved?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/226)
<!-- Reviewable:end -->
