### PR TITLE
Issue #228: Check if promise object has "then" property with "in" operator

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -463,7 +463,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
     }
 
     if (type.generic === "Promise") {
-        assert_own_property(value, "then", "Attribute with a Promise type has a then property");
+        assert_true("then" in value, "Attribute with a Promise type has a then property");
         // TODO: Ideally, we would check on project fulfillment
         // that we get the right type
         // but that would require making the type check async


### PR DESCRIPTION
assert_own_property(value, "then", ...) throws assert error, because "then" property is in prototype and value.hasOwnProperty("then") returns false. Use "in" operator instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/229)
<!-- Reviewable:end -->
