### PR TITLE
idlharness: Swap result and expectation in one of the iterable tests

### DIFF
--- a/idlharness.js
+++ b/idlharness.js
@@ -1384,7 +1384,7 @@ IdlInterface.prototype.test_member_iterable = function(member)
 
     if (isPairIterator) {
         test(function() {
-            assert_equals(self[interfaceName].prototype["entries"], self[interfaceName].prototype[Symbol.iterator], "entries method is not the same as @@iterator");
+            assert_equals(self[interfaceName].prototype[Symbol.iterator], self[interfaceName].prototype["entries"], "entries method is not the same as @@iterator");
         }, "Testing pair iterable interface " + interfaceName);
     } else {
         test(function() {


### PR DESCRIPTION
The pair iterable test was passing its expected value as the actual value,
leading to some confusing error messages when an failure occurred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/235)
<!-- Reviewable:end -->
