### PR TITLE
Fix API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -118,13 +118,13 @@ The properties argument is identical to that for `test()`.
 
 In many cases it is convenient to run a step in response to an event or a
 callback. A convenient method of doing this is through the `step_func` method
-which returns a function that, when called runs a test step. For example
+which returns a function that, when called runs a test step. For example:
 
 ```js
 document.addEventListener("DOMContentLoaded", t.step_func(function() {
   assert_true(e.bubbles, "bubbles should be true");
   t.done();
-});
+}));
 ```
 
 As a further convenience, the `step_func` that calls `done()` can instead
@@ -133,7 +133,7 @@ use `step_func_done`, as follows:
 ```js
 document.addEventListener("DOMContentLoaded", t.step_func_done(function() {
   assert_true(e.bubbles, "bubbles should be true");
-});
+}));
 ```
 
 For asynchronous callbacks that should never execute, `unreached_func` can
@@ -276,7 +276,7 @@ The test title for single page tests is always taken from `document.title`.
 
 Functions for making assertions start `assert_`. The full list of
 asserts avaliable is documented in the [asserts](#list-of-assertions) section
-below. The general signature is
+below. The general signature is:
 
 ```js
 assert_something(actual, expected, description)
@@ -286,7 +286,7 @@ although not all assertions precisely match this pattern e.g. `assert_true`
 only takes `actual` and `description` as arguments.
 
 The description parameter is used to present more useful error messages when
-a test fails
+a test fails.
 
 NOTE: All asserts must be located in a `test()` or a step of an
 `async_test()`, unless the test is a single page test. Asserts outside
@@ -300,7 +300,7 @@ In order to ensure that tests are independent, such state should be cleaned
 up once the test has a result. This can be achieved by adding cleanup
 callbacks to the test. Such callbacks are registered using the `add_cleanup`
 function on the test object. All registered callbacks will be run as soon as
-the test result is known. For example
+the test result is known. For example:
 
 ```js
   test(function() {


### PR DESCRIPTION
  - invalid code examples
  - clean up trailing punctuation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/237)
<!-- Reviewable:end -->
