### PR TITLE
Add fetch_tests_from_window

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -524,16 +524,60 @@ object. These objects are structured as follows:
 
 ## Consolidating tests from other documents ##
 
-If it is desirable to coalesce multiple test suites running in separate
-documents into one primary test document, that is possible through
-`fetch_tests_from_window`. The argument to `fetch_tests_from_window` is any [`Window`](https://html.spec.whatwg.org/multipage/browsers.html#the-window-object)
-capable of accessing the browsing context as either an ancestor or opener.
+`fetch_tests_from_window` will aggregate tests from separate windows or iframes
+into the current document as if they were all part of the same test suite. The
+document of the second window (or iframe) should include `testharness.js`, but
+not `testharnessreport.js`, and use `test`, `async_test`, and `promise_test` in
+the usual manner.
 
-This can be used, for example, to pull in tests from a child that was created
-with `window.open`, or in a frame, such that all tests are ultimately reported
-in the same document. The current test suite will not report completion until
+The current test suite will not report completion until
 all fetched tests are complete, and errors in the child contexts will result in
 failures for the suite in the current context.
+
+Here's an example that uses `window.open`.
+
+`child.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<title>Child context test(s)</title>
+<head>
+  <script src="/resources/testharness.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    test(function(t) {
+      assert_true(true, "true is true");
+    }, "Simple test");
+  </script>
+</body>
+</html>
+```
+
+`test.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<title>Primary test context</title>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    var child_window = window.open("child.html");
+    fetch_tests_from_window(child_window);
+  </script>
+</body>
+</html>
+```
+
+The argument to `fetch_tests_from_window` is any [`Window`](https://html.spec.whatwg.org/multipage/browsers.html#the-window-object)
+capable of accessing the browsing context as either an ancestor or opener.
 
 ## Web Workers ##
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -522,6 +522,19 @@ object. These objects are structured as follows:
  * result - `{ type: "result", test: Test }`
  * complete - `{ type: "complete", tests: [Test, ...], status: TestsStatus }`
 
+## Consolidating tests from other documents ##
+
+If it is desirable to coalesce multiple test suites running in separate
+documents into one primary test document, that is possible through
+`fetch_tests_from_window`. The argument to `fetch_tests_from_window` is any [`Window`](https://html.spec.whatwg.org/multipage/browsers.html#the-window-object)
+capable of accessing the browsing context as either an ancestor or opener.
+
+This can be used, for example, to pull in tests from a child that was created
+with `window.open`, or in a frame, such that all tests are ultimately reported
+in the same document. The current test suite will not report completion until
+all fetched tests are complete, and errors in the child contexts will result in
+failures for the suite in the current context.
+
 ## Web Workers ##
 
 The `testharness.js` script can be used from within [dedicated workers, shared

--- a/examples/apisample18.html
+++ b/examples/apisample18.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Example with iframe that consolidates tests via fetch_tests_from_window</title>
+<script src="../testharness.js"></script>
+<script src="../testharnessreport.js"></script>
+<script>
+var parent_test = async_test("Test executing in parent context");
+</script>
+</head>
+<body onload="parent_test.done()">
+<h1>Fetching Tests From a Child Context</h1>
+<p>This test demonstrates the use of <tt>fetch_tests_from_window</tt> to pull
+tests from an <tt>iframe</tt> into the primary document.</p>
+<p>The test suite is expected to fail due to an unhandled exception in the
+child context.</p>
+<div id="log"></div>
+
+<iframe id="childContext" src="apisample4.htm" style="display:none"></iframe>
+<!-- apisample4 is a failing suite due to an unhandled Error. -->
+
+<script>
+	var childContext = document.getElementById("childContext");
+	fetch_tests_from_window(childContext.contentWindow);
+</script>
+</body>

--- a/examples/apisample19.html
+++ b/examples/apisample19.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<title>Example with iframe that consolidates errors via fetch_tests_from_window</title>
+<title>Example with iframe that consolidates tests via fetch_tests_from_window</title>
 <script src="../testharness.js"></script>
 <script src="../testharnessreport.js"></script>
 <script>
@@ -12,12 +12,12 @@ var parent_test = async_test("Test executing in parent context");
 <h1>Fetching Tests From a Child Context</h1>
 <p>This test demonstrates the use of <tt>fetch_tests_from_window</tt> to pull
 tests from an <tt>iframe</tt> into the primary document.</p>
-<p>The test suite is expected to fail due to an unhandled exception in the
-child context.</p>
+<p>The test suite will not complete until tests in the child context have finished
+executing</p>
 <div id="log"></div>
 
-<iframe id="childContext" src="apisample4.htm" style="display:none"></iframe>
-<!-- apisample4 is a failing suite due to an unhandled Error. -->
+<iframe id="childContext" src="apisample10.html" style="display:none"></iframe>
+<!-- apisample10 has async tests with promises -->
 
 <script>
 	var childContext = document.getElementById("childContext");

--- a/testharness.js
+++ b/testharness.js
@@ -1575,73 +1575,49 @@ policies and contribution forms [3].
     }
 
     /*
-     * A RemoteWorker listens for test events from a worker. These events are
-     * then used to construct and maintain RemoteTest objects that mirror the
-     * tests running on the remote worker.
+     * A RemoteContext listens for test events from a remote test context, such
+     * as another window or a worker. These events are then used to construct
+     * and maintain RemoteTest objects that mirror the tests running in the
+     * remote context.
      */
-    function RemoteWorker(worker) {
+    function RemoteContext(remote, message_target) {
         this.running = true;
         this.tests = new Array();
 
         var this_obj = this;
-        worker.onerror = function(error) { this_obj.worker_error(error); };
+        remote.onerror = function(error) { this_obj.remote_error(error); };
 
-        var message_port;
-
-        if (is_service_worker(worker)) {
-            if (window.MessageChannel) {
-                // The ServiceWorker's implicit MessagePort is currently not
-                // reliably accessible from the ServiceWorkerGlobalScope due to
-                // Blink setting MessageEvent.source to null for messages sent
-                // via ServiceWorker.postMessage(). Until that's resolved,
-                // create an explicit MessageChannel and pass one end to the
-                // worker.
-                var message_channel = new MessageChannel();
-                message_port = message_channel.port1;
-                message_port.start();
-                worker.postMessage({type: "connect"}, [message_channel.port2]);
-            } else {
-                // If MessageChannel is not available, then try the
-                // ServiceWorker.postMessage() approach using MessageEvent.source
-                // on the other end.
-                message_port = navigator.serviceWorker;
-                worker.postMessage({type: "connect"});
+        // Keeping a reference to the remote object and the message handler until
+        // remote_done() is seen prevents the remote object and its message channel
+        // from going away before all the messages are dispatched.
+        this.remote = remote;
+        this.message_target = message_target;
+        this.message_handler = function(message) {
+            if (this_obj.running && message.data && message.source === this_obj.remote &&
+                (message.data.type in this_obj.message_handlers)) {
+                this_obj.message_handlers[message.data.type].call(this_obj, message.data);
             }
-        } else if (is_shared_worker(worker)) {
-            message_port = worker.port;
-        } else {
-            message_port = worker;
-        }
+        };
 
-        // Keeping a reference to the worker until worker_done() is seen
-        // prevents the Worker object and its MessageChannel from going away
-        // before all the messages are dispatched.
-        this.worker = worker;
-
-        message_port.onmessage =
-            function(message) {
-                if (this_obj.running && (message.data.type in this_obj.message_handlers)) {
-                    this_obj.message_handlers[message.data.type].call(this_obj, message.data);
-                }
-            };
+        this.message_target.addEventListener("message", this.message_handler);
     }
 
-    RemoteWorker.prototype.worker_error = function(error) {
+    RemoteContext.prototype.remote_error = function(error) {
         var message = error.message || String(error);
         var filename = (error.filename ? " " + error.filename: "");
-        // FIXME: Display worker error states separately from main document
+        // FIXME: Display remote error states separately from main document
         // error state.
-        this.worker_done({
+        this.remote_done({
             status: {
                 status: tests.status.ERROR,
-                message: "Error in worker" + filename + ": " + message,
+                message: "Error in remote" + filename + ": " + message,
                 stack: error.stack
             }
         });
         error.preventDefault();
     };
 
-    RemoteWorker.prototype.test_state = function(data) {
+    RemoteContext.prototype.test_state = function(data) {
         var remote_test = this.tests[data.test.index];
         if (!remote_test) {
             remote_test = new RemoteTest(data.test);
@@ -1651,31 +1627,33 @@ policies and contribution forms [3].
         tests.notify_test_state(remote_test);
     };
 
-    RemoteWorker.prototype.test_done = function(data) {
+    RemoteContext.prototype.test_done = function(data) {
         var remote_test = this.tests[data.test.index];
         remote_test.update_state_from(data.test);
         remote_test.done();
         tests.result(remote_test);
     };
 
-    RemoteWorker.prototype.worker_done = function(data) {
+    RemoteContext.prototype.remote_done = function(data) {
         if (tests.status.status === null &&
             data.status.status !== data.status.OK) {
             tests.status.status = data.status.status;
             tests.status.message = data.status.message;
             tests.status.stack = data.status.stack;
         }
+        this.message_target.removeEventListener("message", this.message_handler);
         this.running = false;
-        this.worker = null;
+        this.remote = null;
+        this.message_target = null;
         if (tests.all_done()) {
             tests.complete();
         }
     };
 
-    RemoteWorker.prototype.message_handlers = {
-        test_state: RemoteWorker.prototype.test_state,
-        result: RemoteWorker.prototype.test_done,
-        complete: RemoteWorker.prototype.worker_done
+    RemoteContext.prototype.message_handlers = {
+        test_state: RemoteContext.prototype.test_state,
+        result: RemoteContext.prototype.test_done,
+        complete: RemoteContext.prototype.remote_done
     };
 
     /*
@@ -1743,7 +1721,7 @@ policies and contribution forms [3].
         this.test_done_callbacks = [];
         this.all_done_callbacks = [];
 
-        this.pending_workers = [];
+        this.pending_remotes = [];
 
         this.status = new TestsStatus();
 
@@ -1858,7 +1836,7 @@ policies and contribution forms [3].
         return (this.tests.length > 0 && test_environment.all_loaded &&
                 this.num_pending === 0 && !this.wait_for_finish &&
                 !this.processing_callbacks &&
-                !this.pending_workers.some(function(w) { return w.running; }));
+                !this.pending_remotes.some(function(w) { return w.running; }));
     };
 
     Tests.prototype.start = function() {
@@ -1931,18 +1909,74 @@ policies and contribution forms [3].
                  });
     };
 
+    /*
+     * Constructs a RemoteContext that tracks tests from a specific worker.
+     */
+    Tests.prototype.create_remote_worker = function(worker) {
+        var message_port;
+
+        if (is_service_worker(worker)) {
+            // Microsoft Edge's implementation of ServiceWorker's doesn't support MessagePort yet.
+            const isMicrosoftEdgeBrowser = navigator.userAgent.includes("Edge");
+            if (window.MessageChannel && !isMicrosoftEdgeBrowser) {
+                // The ServiceWorker's implicit MessagePort is currently not
+                // reliably accessible from the ServiceWorkerGlobalScope due to
+                // Blink setting MessageEvent.source to null for messages sent
+                // via ServiceWorker.postMessage(). Until that's resolved,
+                // create an explicit MessageChannel and pass one end to the
+                // worker.
+                var message_channel = new MessageChannel();
+                message_port = message_channel.port1;
+                message_port.start();
+                worker.postMessage({type: "connect"}, [message_channel.port2]);
+            } else {
+                // If MessageChannel is not available, then try the
+                // ServiceWorker.postMessage() approach using MessageEvent.source
+                // on the other end.
+                message_port = navigator.serviceWorker;
+                worker.postMessage({type: "connect"});
+            }
+        } else if (is_shared_worker(worker)) {
+            message_port = worker.port;
+        } else {
+            message_port = worker;
+        }
+
+        return new RemoteContext(worker, message_port);
+    };
+
+    /*
+     * Constructs a RemoteContext that tracks tests from a specific window.
+     */
+    Tests.prototype.create_remote_window = function(remote) {
+        return new RemoteContext(remote, window);
+    };
+
     Tests.prototype.fetch_tests_from_worker = function(worker) {
         if (this.phase >= this.phases.COMPLETE) {
             return;
         }
 
-        this.pending_workers.push(new RemoteWorker(worker));
+        this.pending_remotes.push(this.create_remote_worker(worker));
     };
 
     function fetch_tests_from_worker(port) {
         tests.fetch_tests_from_worker(port);
     }
     expose(fetch_tests_from_worker, 'fetch_tests_from_worker');
+
+    Tests.prototype.fetch_tests_from_window = function(remote) {
+        if (this.phase >= this.phases.COMPLETE) {
+            return;
+        }
+
+        this.pending_remotes.push(this.create_remote_window(remote));
+    };
+
+    function fetch_tests_from_window(window) {
+        tests.fetch_tests_from_window(window);
+    }
+    expose(fetch_tests_from_window, 'fetch_tests_from_window');
 
     function timeout() {
         if (tests.timeout_length === null) {

--- a/testharness.js
+++ b/testharness.js
@@ -429,7 +429,7 @@ policies and contribution forms [3].
         var this_obj = this;
         self.addEventListener("message",
                 function(event) {
-                    if (event.data.type && event.data.type === "connect") {
+                    if (event.data && event.data.type && event.data.type === "connect") {
                         if (event.ports && event.ports[0]) {
                             // If a MessageChannel was passed, then use it to
                             // send results back to the main window.  This

--- a/testharness.js
+++ b/testharness.js
@@ -1920,6 +1920,8 @@ policies and contribution forms [3].
 
         if (is_service_worker(worker)) {
             // Microsoft Edge's implementation of ServiceWorker's doesn't support MessagePort yet.
+            // Feature detection isn't a straightforward option here; it's only possible in the
+            // worker's script context.
             const isMicrosoftEdgeBrowser = navigator.userAgent.includes("Edge");
             if (window.MessageChannel && !isMicrosoftEdgeBrowser) {
                 // The ServiceWorker's implicit MessagePort is currently not

--- a/testharness.js
+++ b/testharness.js
@@ -66,6 +66,7 @@ policies and contribution forms [3].
         this.all_loaded = false;
         var this_obj = this;
         this.message_events = [];
+        this.dispatched_messages = [];
 
         this.message_functions = {
             start: [add_start_callback, remove_start_callback,
@@ -102,9 +103,23 @@ policies and contribution forms [3].
         on_event(window, 'load', function() {
             this_obj.all_loaded = true;
         });
+
+        on_event(window, 'message', function(event) {
+            if (event.data && event.data.type === "getmessages" && event.source) {
+                // A window can post "getmessages" to receive a duplicate of every
+                // message posted by this environment so far. This allows subscribers
+                // from fetch_tests_from_window to 'catch up' to the current state of
+                // this environment.
+                for (var i = 0; i < this_obj.dispatched_messages.length; ++i)
+                {
+                    event.source.postMessage(this_obj.dispatched_messages[i], "*");
+                }
+            }
+        });
     }
 
     WindowTestEnvironment.prototype._dispatch = function(selector, callback_args, message_arg) {
+        this.dispatched_messages.push(message_arg);
         this._forEach_windows(
                 function(w, same_origin) {
                     if (same_origin) {
@@ -1579,8 +1594,11 @@ policies and contribution forms [3].
      * as another window or a worker. These events are then used to construct
      * and maintain RemoteTest objects that mirror the tests running in the
      * remote context.
+     * 
+     * An optional third parameter can be used as a predicate to filter incoming
+     * MessageEvents.
      */
-    function RemoteContext(remote, message_target) {
+    function RemoteContext(remote, message_target, message_filter) {
         this.running = true;
         this.tests = new Array();
 
@@ -1593,7 +1611,8 @@ policies and contribution forms [3].
         this.remote = remote;
         this.message_target = message_target;
         this.message_handler = function(message) {
-            if (this_obj.running && message.data && message.source === this_obj.remote &&
+            var passesFilter = !message_filter || message_filter(message);
+            if (this_obj.running && message.data && passesFilter &&
                 (message.data.type in this_obj.message_handlers)) {
                 this_obj.message_handlers[message.data.type].call(this_obj, message.data);
             }
@@ -1954,7 +1973,14 @@ policies and contribution forms [3].
      * Constructs a RemoteContext that tracks tests from a specific window.
      */
     Tests.prototype.create_remote_window = function(remote) {
-        return new RemoteContext(remote, window);
+        remote.postMessage({type: "getmessages"}, "*");
+        return new RemoteContext(
+            remote,
+            window,
+            function(msg) {
+                return msg.source === remote;
+            }
+        );
     };
 
     Tests.prototype.fetch_tests_from_worker = function(worker) {

--- a/testharness.js
+++ b/testharness.js
@@ -1938,10 +1938,10 @@ policies and contribution forms [3].
         var message_port;
 
         if (is_service_worker(worker)) {
-            // Microsoft Edge's implementation of ServiceWorker's doesn't support MessagePort yet.
+            // Microsoft Edge's implementation of ServiceWorker doesn't support MessagePort yet.
             // Feature detection isn't a straightforward option here; it's only possible in the
             // worker's script context.
-            const isMicrosoftEdgeBrowser = navigator.userAgent.includes("Edge");
+            var isMicrosoftEdgeBrowser = navigator.userAgent.includes("Edge");
             if (window.MessageChannel && !isMicrosoftEdgeBrowser) {
                 // The ServiceWorker's implicit MessagePort is currently not
                 // reliably accessible from the ServiceWorkerGlobalScope due to

--- a/testharness.js
+++ b/testharness.js
@@ -1614,7 +1614,10 @@ policies and contribution forms [3].
                 stack: error.stack
             }
         });
-        error.preventDefault();
+
+        if (error.preventDefault) {
+            error.preventDefault();
+        }
     };
 
     RemoteContext.prototype.test_state = function(data) {


### PR DESCRIPTION
The Edge platform team has run into situations where it is desirable to have a primary test window/document that aggregates tests from "child" windows - the common case is window.open().

While testharness.js provides some functionality in WindowTestEnvironment for a parent window to be notified of test results from a child, the test suites are still fundamentally separate entities.

This change adds a new function, 'fetch_tests_from_window', modeled after the existing 'fetch_tests_from_worker'. It abstracts most of the mirroring functionality of RemoteWorker into a new RemoteContext type, which can handle the incoming MessageEvents from a child window the same as it does from a worker.

Additionally, WindowTestContext is augmented to put all outgoing messages into a list (similar to WorkerTestContext), which can be queried by sending the window a 'getmessages' message. This allows fetch_tests_from_window to have the same functionality as fetch_tests_from_worker regarding aggregating tests that have already completed at the time of the call.

The existing postMessage plumbing is unchanged, but fetch_tests_from_window can be leveraged to combine tests running in multiple windows into a single test suite for reporting purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/239)
<!-- Reviewable:end -->
