### PR TITLE
Fail in the presence of duplicate test names

### DIFF
--- a/testharnessreport.js
+++ b/testharnessreport.js
@@ -297,12 +297,7 @@ var metadata_generator = {
     process: function(tests) {
         for (var index = 0; index < tests.length; index++) {
             var test = tests[index];
-            if (this.currentMetadata.hasOwnProperty(test.name)) {
-                this.error('Duplicate test name: ' + test.name);
-            }
-            else {
-                this.currentMetadata[test.name] = this.extractFromTest(test);
-            }
+            this.currentMetadata[test.name] = this.extractFromTest(test);
         }
 
         this.getCachedMetadata();


### PR DESCRIPTION
Test names are presumed to be unique within test files--this allows
consumers to use them for identification purposes. Duplicated names
violate this expectation and should therefore be rejected. Previously,
the default "reporter" implementation identified this case only
informally (through modification to the test document)--the error was
not communicated to whatever "runner" process initiated test execution.

Formally report an error in the presence of duplicate test names. Remove
the equivalent code in the default "reporter" implementation (as the
error is now communicated via the typical "test failure" mechanism).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/240)
<!-- Reviewable:end -->
