### PR TITLE
Require "thenable" for `promise_test`

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -532,7 +532,16 @@ policies and contribution forms [3].
             });
             var promise = test.step(func, test, test);
             test.step(function() {
-                assert_not_equals(promise, undefined);
+                if (promise === undefined || promise === null) {
+                    throw new Error(
+                        "testharness.js: Function provided to `promise_test` did not return a value.");
+                }
+
+                if (typeof promise.then !== "function") {
+                    throw new Error(
+                        "testharness.js: Function provided to `promise_test` did not return a \"thenable\" value.");
+                }
+
             });
             Promise.resolve(promise).then(
                     function() {


### PR DESCRIPTION
The `promise_test` function is intended to run an asynchronous test, interpreting its status via a "thenable" object provided via return value. Previously, it would accept functions that did not provide such a value, and this meant that tests could fail silently. Because there is no use case for using `promise_test` in this way, the condition always reflects a programming error.

Update the harness to explicitly fail the test whenever this occurs, prompting contributors to correct their usage prior to submitting the test.

@jgraham This is in response to https://github.com/w3c/web-platform-tests/pull/5228 . It's difficult to say how many tests this change might effect; would you mind vetting it against WPT using Mozilla's testing infrastructure, like we did with https://github.com/w3c/testharness.js/pull/240 ?