### PR TITLE
get_harness_url() returns undefined on failure, not null

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -2204,7 +2204,7 @@ policies and contribution forms [3].
         }
 
         var harness_url = get_harness_url();
-        if (harness_url !== null) {
+        if (harness_url !== undefined) {
             var stylesheet = output_document.createElementNS(xhtml_ns, "link");
             stylesheet.setAttribute("rel", "stylesheet");
             stylesheet.setAttribute("href", harness_url + "testharness.css");


### PR DESCRIPTION
This resulted in trying to fetch "undefinedtestharness.css", which is
probably a 404 on most servers.  Strict equality checking is not always
an advantage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/254)
<!-- Reviewable:end -->
