### PR TITLE
Make HTTPS tests fail if they are loaded over HTTP

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -504,6 +504,18 @@ policies and contribution forms [3].
         return 'ServiceWorker' in self && worker instanceof ServiceWorker;
     }
 
+    function enforce_https() {
+        var pos = 0;
+        if (location && location.pathname) {
+            pos = location.pathname.indexOf(".https.");
+            if ((pos !== -1) && (location.protocol !== "https:")) {
+                assert(false, "enforce_https", "Test page must be loaded over HTTPS.",
+                        "Protocol is ${protocol}", {protocol:location.protocol});
+            }
+        }
+    }
+
+
     /*
      * API functions
      */
@@ -513,6 +525,7 @@ policies and contribution forms [3].
         var test_name = name ? name : test_environment.next_default_test_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
+        test_obj.step(enforce_https, test_obj, test_obj);
         test_obj.step(func, test_obj, test_obj);
         if (test_obj.phase === test_obj.phases.STARTED) {
             test_obj.done();
@@ -529,6 +542,7 @@ policies and contribution forms [3].
         var test_name = name ? name : test_environment.next_default_test_name();
         properties = properties ? properties : {};
         var test_obj = new Test(test_name, properties);
+        test_obj.step(enforce_https, test_obj, test_obj);
         if (func) {
             test_obj.step(func, test_obj, test_obj);
         }


### PR DESCRIPTION
This PR replaces PR #207. Same goal: make the test harness fail HTTPS-only tests when they are loaded over HTTP with a "Test page must be loaded over HTTPS" message.

The new PR addresses the request from @jgraham to relax the check and look for `https` within the file name without assuming that the extension will be `.html`, and without assuming `https` will be the last dot flag before the extension.

Note I stuck to `indexOf(".https.")` because I think that reads better than `.split(".").slice(1).slice(0, -1).indexOf("https")`. This should yield the same result.