### PR TITLE
Start MessagePort for SharedWorkers

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -1980,6 +1980,7 @@ policies and contribution forms [3].
             }
         } else if (is_shared_worker(worker)) {
             message_port = worker.port;
+            message_port.start();
         } else {
             message_port = worker;
         }


### PR DESCRIPTION
This change fixes [w3c\web-platform-tests#5568](https://github.com/w3c/web-platform-tests/issues/5568). My previous change (39051c9) caused a regression in SharedWorker tests by switching from an `onmessage` handler to `addEventListener` for message events. The fix is to call `start()` on the SharedWorker MessagePort the same way we do for ServiceWorkers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/testharness.js/262)
<!-- Reviewable:end -->
